### PR TITLE
 removed BOM in utf-8 file with notepad++

### DIFF
--- a/UnitTests/XSD-Subsets/xsd_export_wegkantkast.xsd
+++ b/UnitTests/XSD-Subsets/xsd_export_wegkantkast.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fdo.osgeo.org/schemas/feature/Schema1"
            xmlns:fdo="http://fdo.osgeo.org/schemas" xmlns:gml="http://www.opengis.net/gml"
            xmlns:Schema1="http://fdo.osgeo.org/schemas/feature/Schema1" elementFormDefault="qualified"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removed Byte Order Mark (BOM) from the UTF-8 encoded file to ensure consistency and avoid potential parsing issues.