### PR TITLE
Dev christiaan sprint 9 rework select all classes

### DIFF
--- a/Domain/step_domain/RelationChangeDomain.py
+++ b/Domain/step_domain/RelationChangeDomain.py
@@ -27,8 +27,6 @@ from GUI.screens.RelationChange_elements.RelationChangeHelpers import RelationCh
 from GUI.screens.screen_interface.RelationChangeScreenInterface import \
     RelationChangeScreenInterface
 
-from line_profiler_pycharm import profile
-
 ROOT_DIR = Path(__file__).parent.parent
 
 def async_save_assets(func):
@@ -536,7 +534,6 @@ class RelationChangeDomain:
         cls.selected_object = selected_object
 
     @classmethod
-    @profile
     def add_all_possible_relations_between_selected_and_related_objects(
             cls, relation_list: list[OSLORelatie],selected_object: RelationInteractor,
             related_objects: list[RelationInteractor]) -> None:
@@ -640,7 +637,6 @@ class RelationChangeDomain:
         return typeURI in cls.possible_relations_per_class_dict.keys()
 
     @classmethod
-    @profile
     def collect_possible_relations_to_class_types_from(cls, selected_object:RelationInteractor):
         """
         Collects possible relations for a specified selected object based on its type.
@@ -679,7 +675,6 @@ class RelationChangeDomain:
             extra={"timing_ref": f"collect_possible_relations_classes"})
 
     @classmethod
-    @profile
     def get_all_concrete_relation_from_full_model(cls, selected_object:RelationInteractor):
         """
         Retrieves all concrete relations from the full model for a specified selected object.
@@ -708,7 +703,6 @@ class RelationChangeDomain:
 
 
     @classmethod
-    @profile
     def get_same_relations_in_list(cls, relation_list: list[RelatieObject],
                                    relation_def: OSLORelatie,
                                    selected_object: RelationInteractor,

--- a/Domain/step_domain/TemplateDomain.py
+++ b/Domain/step_domain/TemplateDomain.py
@@ -26,7 +26,9 @@ from GUI.translation.GlobalTranslate import GlobalTranslate
 class TemplateDomain:
 
     classes: list[OSLOClass] = []
-    has_a_class_with_deprecated_attributes = False
+    selected_classes_indexes: list[int] = []
+    all_classes_selected: bool = True
+    has_a_class_with_deprecated_attributes: bool = False
 
 
     @classmethod
@@ -124,6 +126,7 @@ class TemplateDomain:
                 OTLLogger.logger.info("otlmow-model version is high enough")
 
             cls.classes = modelbuilder.filter_relations_and_abstract()
+            cls.select_all_classes()
             cls.has_a_class_with_deprecated_attributes = TemplateDomain.check_for_no_deprecated_present()
 
 
@@ -136,6 +139,17 @@ class TemplateDomain:
         cls.update_frontend()
         cls.get_screen().reset_ui(GlobalTranslate._)
 
+    @classmethod
+    def select_all_classes(cls):
+        cls.selected_classes_indexes = list(range(len(cls.classes)))
+        TemplateDomain.all_classes_selected = True
+        cls.get_screen().set_all_classes_selected()
+
+    @classmethod
+    def deselect_all_classes(cls):
+        cls.selected_classes_indexes.clear()
+        TemplateDomain.all_classes_selected = False
+        cls.get_screen().deselect_all_classes()
 
     @classmethod
     def update_frontend(cls):
@@ -184,3 +198,12 @@ class TemplateDomain:
                 OTLLogger.logger.error("Opening a file on this OS is not implemented yet")
         else:
             cls.get_screen().open_folder_of_created_template(document_path)
+
+    @classmethod
+    def toggle_class_index(cls,index:int):
+        if index in cls.selected_classes_indexes:
+            cls.selected_classes_indexes.remove(index)
+        else:
+            cls.selected_classes_indexes.append(index)
+        cls.get_screen().update_label_under_list(len(cls.classes),len(cls.selected_classes_indexes))
+

--- a/Domain/step_domain/TemplateDomain.py
+++ b/Domain/step_domain/TemplateDomain.py
@@ -182,21 +182,23 @@ class TemplateDomain:
 
     @classmethod
     @add_loading_screen
-    async def async_export_template(cls, document_path:Path ,selected_classes: list[str],
+    async def async_export_template(cls, document_path:Path,
                         generate_choice_list: bool, geometry_column_added: bool,
                         export_attribute_info: bool, highlight_deprecated_attributes:bool,
                         amount_of_examples: int):
-        return await cls.export_template(document_path,selected_classes,generate_choice_list,
+        return await cls.export_template(document_path,generate_choice_list,
                                    geometry_column_added,export_attribute_info,
                                    highlight_deprecated_attributes,amount_of_examples)
 
     @classmethod
-    async def export_template(cls, document_path:Path ,selected_classes: list[str],
+    async def export_template(cls, document_path:Path ,
                         generate_choice_list: bool, geometry_column_added: bool,
                         export_attribute_info: bool, highlight_deprecated_attributes:bool,
                         amount_of_examples: int):
 
         project = global_vars.current_project
+
+        selected_classes = [cls.classes[i].objectUri for i in cls.selected_classes_indexes]
 
         if not document_path or not project:
             return

--- a/Domain/step_domain/TemplateDomain.py
+++ b/Domain/step_domain/TemplateDomain.py
@@ -256,3 +256,12 @@ class TemplateDomain:
             return
 
         cls.all_classes_selected = False
+
+    @classmethod
+    def set_selected_indexes(cls,new_indexes: list[int]):
+
+        cls.selected_classes_indexes = new_indexes
+        cls.get_screen().update_label_under_list(
+            total_amount_of_items=cls.get_total_amount_of_classes(),
+            counter=len(cls.selected_classes_indexes))
+        cls.update_all_classes_selected_state()

--- a/GUI/screens/Home_elements/OverviewTable.py
+++ b/GUI/screens/Home_elements/OverviewTable.py
@@ -222,7 +222,7 @@ class OverviewTable(QTableWidget):
         :return: None
         """
 
-        self.main_window.setCurrentIndex(1)
+        # self.main_window.setCurrentIndex(1)
         project_ref = self.item(row, 0).data(1)
 
         HomeDomain.open_project(project_ref=project_ref)

--- a/GUI/screens/TemplateScreen.py
+++ b/GUI/screens/TemplateScreen.py
@@ -19,6 +19,7 @@ from Domain.util.Helpers import Helpers
 from GUI.dialog_windows.ExportToTemplateWindow import ExportToTemplateWindow
 from GUI.dialog_windows.file_picker_dialog.TemplateSaveFilePickerDialog import \
     TemplateSaveFilePickerDialog
+from GUI.screens.TemplateScreen_elements.ClassListWidget import ClassListWidget
 from GUI.screens.general_elements.ButtonWidget import ButtonWidget
 from GUI.dialog_windows.ChangeSubsetWindow import ChangeSubsetWindow
 from GUI.screens.screen_interface.TemplateScreenInterface import TemplateScreenInterface
@@ -285,7 +286,7 @@ class TemplateScreen(TemplateScreenInterface):
         # class GUI list elements
         self.select_all_classes = QCheckBox()
         self.add_resetable_field(self.select_all_classes,default_value=True)
-        self.all_classes = QListWidget()
+        self.all_classes = ClassListWidget()
         self.selected = 0
         self.label_counter = QLabel()
 
@@ -336,9 +337,6 @@ class TemplateScreen(TemplateScreenInterface):
         options_menu = QFrame()
         main_layout = QVBoxLayout()
 
-
-        # self.select_all_classes.setText(self._("select_all_classes"))
-        # self.select_all_classes.stateChanged.connect(lambda: self.select_all_classes_clicked())
 
         self.general_settings_title.setProperty('class', 'settings-title')
         self.general_settings_title.setText(self._("general_settings"))
@@ -405,10 +403,7 @@ class TemplateScreen(TemplateScreenInterface):
         #                         self.ExportOptionId.ALL_DATA)
 
         self.radio_button_group.addButton(self.radio_button_expanded_info, self.TemplateOptionId.EXTRA_INFO)
-        # self.button_group.setId(self.radio_button_export_only_unedited_data,
-        #                         self.ExportOptionId.ONLY_UNEDITED_DATA)
 
-        # self.button_group.idClicked.connect(self.on_radio_button_click)
         self.radio_button_davie_conform.setChecked(True)
 
         button_box_layout.addWidget(self.template_format_label)
@@ -627,11 +622,10 @@ class TemplateScreen(TemplateScreenInterface):
         self.select_all_classes.clicked.connect(lambda: self.select_all_classes_clicked())
         self.all_classes.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
 
-        # self.all_classes.itemSelectionChanged.connect(lambda: self.update_label_under_list()) # reacts to programmatical changes in the list selection
-        # self.all_classes.itemClicked.connect(lambda: self.update_label_under_list()) # reacts only to user changes in the list selection
-        self.all_classes.itemClicked.connect(self.class_items_clicked_listener)
-
-        # self.all_classes.itemPressed.connect(lambda: self.list_item_pressed_listener())
+        self.all_classes.doubleClicked.connect(
+            lambda item:
+                 self.all_classes.itemFromIndex(item).setSelected(not self.all_classes.itemFromIndex(item).isSelected())
+        )
         self.label_counter.setText(self._(f"{self.selected} classes selected"))
 
         vertical_layout.addWidget(self.select_all_classes, alignment=Qt.AlignmentFlag.AlignTop)
@@ -672,6 +666,8 @@ class TemplateScreen(TemplateScreenInterface):
     def class_items_clicked_listener(self, selected_item):
         row_index = selected_item.data(1)[1]
         TemplateDomain.toggle_class_index(row_index)
+
+
 
 
     def update_label_under_list(self,total_amount_of_items:int,counter:int) -> None:

--- a/GUI/screens/TemplateScreen.py
+++ b/GUI/screens/TemplateScreen.py
@@ -626,7 +626,11 @@ class TemplateScreen(TemplateScreenInterface):
         self.select_all_classes.setText(self._("select_all_classes"))
         self.select_all_classes.clicked.connect(lambda: self.select_all_classes_clicked())
         self.all_classes.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
-        self.all_classes.itemSelectionChanged.connect(lambda: self.update_label_under_list())
+
+        # self.all_classes.itemSelectionChanged.connect(lambda: self.update_label_under_list()) # reacts to programmatical changes in the list selection
+        # self.all_classes.itemClicked.connect(lambda: self.update_label_under_list()) # reacts only to user changes in the list selection
+        self.all_classes.itemClicked.connect(self.class_items_clicked_listener)
+
         # self.all_classes.itemPressed.connect(lambda: self.list_item_pressed_listener())
         self.label_counter.setText(self._(f"{self.selected} classes selected"))
 
@@ -665,11 +669,16 @@ class TemplateScreen(TemplateScreenInterface):
             self.operator_name.setText("Loading")
             self.otl_version.setText("Loading")
 
-    def update_label_under_list(self):
-        total_amount_of_items = self.get_total_amount_of_items()
+    def class_items_clicked_listener(self, selected_item):
+        row_index = self.all_classes.indexFromItem(selected_item).row()
+        TemplateDomain.toggle_class_index(row_index)
 
 
-        counter = self.count_selected_items()
+    def update_label_under_list(self,total_amount_of_items:int,counter:int) -> None:
+        # total_amount_of_items = self.get_total_amount_of_items()
+
+
+        # counter = self.count_selected_items()
         self.selected = counter
         self.label_counter.setText(self._("{selected} classes selected").format(selected=self.selected))
         if counter:
@@ -698,16 +707,7 @@ class TemplateScreen(TemplateScreenInterface):
         if self.has_agent:
             count -= 1
         return count
-    def list_item_pressed_listener(self):
-        total_amount_of_items = self.get_total_amount_of_items()
-        counter = self.count_selected_items()
 
-        if total_amount_of_items == counter:
-            self.select_all_classes.setChecked(True)
-        else:
-            self.select_all_classes.setChecked(False)
-
-        # self.update_label_under_list()
 
     def select_all_classes_clicked(self):
         """
@@ -724,14 +724,21 @@ class TemplateScreen(TemplateScreenInterface):
         if not self.all_classes.isEnabled():
             return
         elif self.select_all_classes.isChecked():
-            self.all_classes.selectAll()
-            # self.update_label_under_list()
+            TemplateDomain.select_all_classes()
+
+            # self.all_classes.selectAll()
         else:
-            total_amount_of_items = self.get_total_amount_of_items()
-            counter = self.count_selected_items()
-            if total_amount_of_items == counter:
-                self.all_classes.clearSelection()
-                # self.update_label_under_list()
+            TemplateDomain.deselect_all_classes()
+
+    def deset_all_classes_selected(self) -> None:
+        total_amount_of_items = self.get_total_amount_of_items()
+        counter = self.count_selected_items()
+        if total_amount_of_items == counter:
+            self.all_classes.clearSelection()
+            # self.update_label_under_list()
+
+    def set_all_classes_selected(self) -> None:
+        self.all_classes.selectAll()
 
     def export_template_listener(self) -> None:  # sourcery skip: use-named-expression
         """
@@ -963,8 +970,9 @@ class TemplateScreen(TemplateScreenInterface):
             self.all_classes.addItem(item)
             if has_a_class_with_deprecated_attributes:
                 self.show_deprecated_attributes.setEnabled(False)
-        if self.select_all_classes.isChecked():
-            self.select_all_classes_clicked()
+
+        # if self.select_all_classes.isChecked():
+        #     self.select_all_classes_clicked()
 
 
 

--- a/GUI/screens/TemplateScreen.py
+++ b/GUI/screens/TemplateScreen.py
@@ -768,12 +768,9 @@ class TemplateScreen(TemplateScreenInterface):
         else:
             amount_of_examples = 0
 
-        selected_classes = [item.data(1)[0] for item in self.all_classes.selectedItems()]
-
         event_loop = asyncio.get_event_loop()
         event_loop.create_task(TemplateDomain.async_export_template(
             document_path=document_path,
-            selected_classes=selected_classes,
             generate_choice_list=self.add_choice_list.isChecked(),
             geometry_column_added=self.add_geometry_attributes.isChecked(),
             export_attribute_info=attribute_description,

--- a/GUI/screens/TemplateScreen_elements/ClassListWidget.py
+++ b/GUI/screens/TemplateScreen_elements/ClassListWidget.py
@@ -1,0 +1,15 @@
+from PyQt6.QtWidgets import QListWidget
+
+from Domain.step_domain.TemplateDomain import TemplateDomain
+
+
+class ClassListWidget(QListWidget):
+
+
+
+    def mouseReleaseEvent(self, e):
+        super().mouseReleaseEvent(e)
+        self.sync_selected_items_with_backend()
+
+    def sync_selected_items_with_backend(self):
+        TemplateDomain.set_selected_indexes([item.data(1)[1] for item in self.selectedItems()])

--- a/GUI/screens/screen_interface/TemplateScreenInterface.py
+++ b/GUI/screens/screen_interface/TemplateScreenInterface.py
@@ -82,7 +82,8 @@ class TemplateScreenInterface(Screen):
         pass
 
     @abstractmethod
-    def set_classes(self, classes, has_a_class_with_deprecated_attributes) -> None:
+    def set_classes(self, classes,selected_classes: list[int],
+                    all_classes_selected_checked:bool, has_a_class_with_deprecated_attributes) -> None:
         pass
 
     def open_folder_of_created_template(self, document_path:Path):
@@ -98,4 +99,8 @@ class TemplateScreenInterface(Screen):
 
     @abstractmethod
     def deselect_all_classes(self) -> None:
+        pass
+
+    @abstractmethod
+    def update_all_classes_selected(self, state: bool) -> None:
         pass

--- a/GUI/screens/screen_interface/TemplateScreenInterface.py
+++ b/GUI/screens/screen_interface/TemplateScreenInterface.py
@@ -68,10 +68,6 @@ class TemplateScreenInterface(Screen):
         pass
 
 
-    @abstractmethod
-    def update_label_under_list(self) -> None:
-        pass
-
 
     @abstractmethod
     def select_all_classes_clicked(self) -> None:
@@ -90,4 +86,16 @@ class TemplateScreenInterface(Screen):
         pass
 
     def open_folder_of_created_template(self, document_path:Path):
+        pass
+
+    @abstractmethod
+    def update_label_under_list(self,total_amount_of_items:int,counter:int) -> None:
+        pass
+
+    @abstractmethod
+    def set_all_classes_selected(self) -> None:
+        pass
+
+    @abstractmethod
+    def deselect_all_classes(self) -> None:
         pass


### PR DESCRIPTION
## Summary by Sourcery

Refactor the class selection mechanism in the Template screen by centralizing state management within the `TemplateDomain`.

Enhancements:
- Move class selection state management (selected items, 'Select All' status) from `TemplateScreen` to `TemplateDomain`.
- Update `TemplateScreen` to reflect state changes driven by `TemplateDomain`.
- Update the `TemplateScreenInterface` to align with the refactored methods in `TemplateScreen`.